### PR TITLE
handling 'rogue' processes

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -19,6 +19,7 @@ var bunyan = require('bunyan');
 var spawnMonitor = require('./monitor.js');
 var executor = require('nscale-util').executor();
 var async = require('async');
+var handleRogueProcesses = require('./handler');
 
 var reSsh = /([a-zA-Z0-9_.-]+)\@([a-zA-Z0-9_.-]+):[a-zA-Z0-9_.-]+\/([a-zA-Z0-9_.-]+)\.git(?:\#([a-zA-Z0-9_.-]+))?/i;
 var reHttp = /https?:\/\/(?:([a-zA-Z0-9_.-\\%]+)(?::([a-zA-Z0-9_.-]+))@){0,1}([a-zA-Z0-9_.-]+)\/(?:[a-zA-Z0-9_.-]+\/)+([a-zA-Z0-9_-]+)(?:\.git){0,1}(?:\#([a-zA-Z0-9_.-]+)){0,1}/i;
@@ -52,6 +53,11 @@ module.exports = function(config, logger) {
   var monitors = {};
 
   logger = logger || bunyan.createLogger({name: 'process-container'});
+  
+  handleRogueProcesses(logger, function(err) {
+    if (err) { logger.debug(err); }
+  });
+
 
   /**
    * build the container
@@ -229,9 +235,6 @@ module.exports = function(config, logger) {
       }
     });
   }
-
-  // kill all running process on exit
-  process.on('exit', release.bind(null, null));
 
   return {
     build: build,

--- a/lib/container.js
+++ b/lib/container.js
@@ -54,9 +54,16 @@ module.exports = function(config, logger) {
 
   logger = logger || bunyan.createLogger({name: 'process-container'});
   
-  handleRogueProcesses(logger, function(err) {
-    if (err) { logger.debug(err); }
-  });
+
+  /**
+   * Service function to handle any rogue processes
+   */
+  var rogueProcessService = function rogueProcessService(cb) {
+    handleRogueProcesses(logger, function(err) {
+      if (err) { logger.debug(err); }
+      cb(err);
+    });
+  };
 
 
   /**
@@ -246,6 +253,7 @@ module.exports = function(config, logger) {
     undeploy: undeploy,
     add: deploy,
     remove: undeploy,
+    service: rogueProcessService,
     release: release
   };
 };

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -1,0 +1,76 @@
+/**
+* helper file for handling leftover processes which may not have been killed off
+* e.g. is nscale was killed with SIGKILL
+* this file finds those processes and kills them off
+*/
+
+var ps = require('ps-node');
+var fs = require('fs');
+var path = require('path');
+var async = require('async');
+
+var dataDir = path.join(process.env.HOME, '/.nscale/data/');
+
+module.exports = function(logger, cb) {
+
+var handleRogueProcesses = function(cb) {
+    checkForPidFiles(function(err, pids) {
+      if (err) { cb(err); }
+      if (pids) {
+        logger.debug('found leftover pidfiles', pids);
+        killProcesses(pids, function(err) {
+          if (err) { cb(err); }
+          cb();
+        });
+      }
+      else { cb(); }
+    });
+};
+
+/**
+  *  internal function which checks for the existence of leftover pid files
+  *  a leftover pid file may exist if nscale was killed with SIGKILL 
+  *  while process containers were running
+  */
+  var checkForPidFiles = function(cb) {
+    var dir = path.join(process.env.HOME, '/.nscale/data');
+
+    fs.readdir(dir, function(err, files) {
+      if (err) { cb(err); }
+      async.filter(files, function(file, callback) { callback(file.indexOf('.pid') > 0); }, function(pidFiles) {
+        (pidFiles.length > 0) ? cb(null, pidFiles): cb();
+      });
+    });
+  };
+
+  /**
+   *  internal function which finds rogue processes and kills them off
+   *  pidFiles - the files supplied from the _checkForPidFiles function
+   */
+  var killProcesses = function(pidFiles, cb) {
+    
+    function onNextFile(pidFile, callback) {
+      var pid = pidFile.replace('.pid', '')
+
+      ps.lookup({'pid': pid}, function(err, resultList) {
+        if (err) { callback(err) }
+        var rogueProcess = resultList[0];
+        fs.unlinkSync(path.join(dataDir, pidFile));
+        if (rogueProcess) {
+          ps.kill(pid, function(err) {
+            if (err) {logger.error(err); callback(err);}
+            logger.debug('killed rogue process', pid);
+            callback(null);
+          });
+        }
+        else {
+          callback(null)
+        }
+      });
+    }
+
+    async.each(pidFiles, onNextFile, cb);
+  };
+
+  handleRogueProcesses(cb);
+}

--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -10,6 +10,8 @@ var path = require('path');
 // needed to support nvm and local env variables
 var baseCmd = 'test -f ~/.bashrc && source ~/.bashrc; test -f ~/.bash_profile && source ~/.bash_profile; exec ';
 
+var dataDir = path.join(process.env.HOME, '/.nscale/data/');
+
 function dockerHostIp() {
   var split;
   if (process.env.DOCKER_HOST) {
@@ -105,6 +107,8 @@ module.exports = function spawnMonitor(cmd, cwd, watch, logger, logFile, ignored
 
     child.on('exit', function(code) {
       logger.info({ pid: pid, code: code }, 'dead');
+      //delete the pid file
+      fs.unlinkSync(path.join(dataDir, String(pid) + '.pid'));
       child = null;
 
       if (code && cb) {
@@ -119,10 +123,14 @@ module.exports = function spawnMonitor(cmd, cwd, watch, logger, logFile, ignored
 
     setTimeout(function() {
       logger.info({ pid: pid }, 'running');
-      if (cb) {
-        cb(null);
-        cb = null;
-      }
+      writePidFile(pid, function(err) {
+        if (err) { logger.error(err); }
+        logger.debug('pid file written');
+        if (cb) {
+          cb(null);
+          cb = null;
+        }
+      });
     }, 200);
   }
 
@@ -147,6 +155,14 @@ module.exports = function spawnMonitor(cmd, cwd, watch, logger, logFile, ignored
     } else if (typeof cb === 'function') {
       cb();
     }
+  }
+
+  function writePidFile(pid, cb) {
+    var pidFile = path.join(dataDir, String(pid) + '.pid');
+    fs.writeFile(pidFile, pid, function(err) {
+      if (err) { cb(err); }
+      cb();
+    });
   }
 
   watcher.kill = function(cb) {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "chokidar-child": "^0.1.1",
     "nscale-util": "^0.12.0",
     "pump": "^1.0.0",
-    "through2": "^0.6.3"
+    "through2": "^0.6.3",
+    "ps-node": "^0.0.4"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This works by writing the pid files of the processes to the ~/.nscale/data directory. When the kernel boots, the the process-container is required and the handler checks said directory for pid files and kills the processes.

I used a module I found called [ps-node.](https://www.npmjs.com/package/ps-node) I looked at their GH and it isn't incredibly active however it's pretty good and appears to support windows, mac and linux. Either way, it's a very simple module (one file) so maybe we could eventually show it some love or even fork it because it's got some vital functionality.

I think as an initial approach it might be naive - What if someone manually inserts pid files? It could be a vulnerability in that regard. Strangely enough I tried to attack some of my own processes, music player, browser, terminal windows etc, and the lookup of their pids returned nothing so nothing was killed. It's still a concern though.

@mcollina @McDonnellDean could you guys test it on Mac and let me know what you think?